### PR TITLE
Repair compilation under Visual Studio 2013.

### DIFF
--- a/include/libport/cctype
+++ b/include/libport/cctype
@@ -13,7 +13,7 @@
 
 # include <libport/detect-win32.h>
 
-# if defined WIN32
+# if defined(WIN32) && (_MSC_VER < 1700)
 #  undef isascii
 #  undef isblank
 

--- a/include/libport/cctype.hxx
+++ b/include/libport/cctype.hxx
@@ -8,7 +8,7 @@
  * See the LICENSE file for more information.
  */
 
-#if defined WIN32
+#if defined(WIN32) && (_MSC_VER < 1700)
 
 extern "C"
 {

--- a/include/libport/cmath
+++ b/include/libport/cmath
@@ -36,6 +36,9 @@
   "Either include <libport/cmath> first, or #define _USE_MATH_DEFINES before yourself."
 #  endif
 
+
+#if (_MSC_VER < 1700)
+
 namespace std
 {
 
@@ -55,6 +58,8 @@ namespace std
 #  undef LIBPORT_BOUNCE
 
 }
+
+#endif
 
 # endif // ! defined _MSC_VER
 

--- a/include/libport/tr1/type_traits
+++ b/include/libport/tr1/type_traits
@@ -19,8 +19,8 @@
 
 # include <libport/config.h>
 
-# ifdef LIBPORT_HAVE_TR1_TYPE_TRAITS
-#  include <tr1/type_traits>
+# if defined(LIBPORT_HAVE_TR1_TYPE_TRAITS) || (_MSC_VER >= 1700) 
+#  include <type_traits>
 #  define BOOST_TR1_TYPE_TRAITS_HPP_INCLUDED
 # else
 #  include <boost/tr1/type_traits.hpp>


### PR DESCRIPTION
Add checks on the type of compiler and when is it Visual Studio 2013 or
higher disable some feature in libport as boost::type_traits because they
are defined in c++11 standart.
